### PR TITLE
Add pkgdown configuration and function families

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+^_pkgdown\.yml$
+^docs$
+^Test\.md$

--- a/R/BuildUrl.R
+++ b/R/BuildUrl.R
@@ -5,6 +5,7 @@
 #' @param Endpoint Character string specifying the API endpoint path.
 #'
 #' @return A character string containing the full URL.
+#' @family utilities
 #' @keywords internal
 .BuildUrl <- function(Endpoint) {
     BaseUrl <- "https://api.usemotion.com/v1"

--- a/R/CreateProject.R
+++ b/R/CreateProject.R
@@ -6,6 +6,7 @@
 #' @param Project List describing the project fields.
 #'
 #' @return data.table with the created project.
+#' @family projects
 #' @export
 CreateProject <- function(Token, Project) {
     Result <- .PerformRequest("POST", "/projects", Token, Body = Project)

--- a/R/CreateTask.R
+++ b/R/CreateTask.R
@@ -6,6 +6,7 @@
 #' @param Task List describing task fields.
 #'
 #' @return data.table with the created task.
+#' @family tasks
 #' @export
 CreateTask <- function(Token, Task) {
     Result <- .PerformRequest("POST", "/tasks", Token, Body = Task)

--- a/R/DeleteProject.R
+++ b/R/DeleteProject.R
@@ -6,6 +6,7 @@
 #' @param ProjectId Identifier of the project to delete.
 #'
 #' @return data.table with deletion confirmation.
+#' @family projects
 #' @export
 DeleteProject <- function(Token, ProjectId) {
     Endpoint <- paste0("/projects/", ProjectId)

--- a/R/DeleteTask.R
+++ b/R/DeleteTask.R
@@ -6,6 +6,7 @@
 #' @param TaskId Identifier of the task to delete.
 #'
 #' @return data.table with deletion confirmation.
+#' @family tasks
 #' @export
 DeleteTask <- function(Token, TaskId) {
     Endpoint <- paste0("/tasks/", TaskId)

--- a/R/GetProjects.R
+++ b/R/GetProjects.R
@@ -6,6 +6,7 @@
 #' @param Query Optional list of query parameters.
 #'
 #' @return data.table of projects.
+#' @family projects
 #' @export
 GetProjects <- function(Token, Query = NULL) {
     Result <- .PerformRequest("GET", "/projects", Token, Query = Query)

--- a/R/GetTasks.R
+++ b/R/GetTasks.R
@@ -6,6 +6,7 @@
 #' @param Query Optional list of query parameters.
 #'
 #' @return data.table of tasks.
+#' @family tasks
 #' @export
 GetTasks <- function(Token, Query = NULL) {
     Result <- .PerformRequest("GET", "/tasks", Token, Query = Query)

--- a/R/HandleResponse.R
+++ b/R/HandleResponse.R
@@ -5,6 +5,7 @@
 #' @param Response httr response object.
 #'
 #' @return Parsed content as a `data.table` or other R object.
+#' @family utilities
 #' @keywords internal
 .HandleResponse <- function(Response) {
     Content <- content(Response, as = "parsed", type = "application/json")

--- a/R/PerformRequest.R
+++ b/R/PerformRequest.R
@@ -9,6 +9,7 @@
 #' @param Query Optional list of query parameters.
 #'
 #' @return Parsed response object.
+#' @family utilities
 #' @keywords internal
 .PerformRequest <- function(Method, Endpoint, Token, Body = NULL, Query = NULL) {
     Url <- .BuildUrl(Endpoint)

--- a/R/UpdateProject.R
+++ b/R/UpdateProject.R
@@ -7,6 +7,7 @@
 #' @param Project List describing project fields to update.
 #'
 #' @return data.table with the updated project.
+#' @family projects
 #' @export
 UpdateProject <- function(Token, ProjectId, Project) {
     Endpoint <- paste0("/projects/", ProjectId)

--- a/R/UpdateTask.R
+++ b/R/UpdateTask.R
@@ -7,6 +7,7 @@
 #' @param Task List describing task fields to update.
 #'
 #' @return data.table with the updated task.
+#' @family tasks
 #' @export
 UpdateTask <- function(Token, TaskId, Task) {
     Endpoint <- paste0("/tasks/", TaskId)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,15 @@
+template:
+  bootstrap: 5
+reference:
+  - title: Projects
+    desc: Functions for interacting with Motion projects.
+    contents:
+      - '@family projects'
+  - title: Tasks
+    desc: Functions for interacting with Motion tasks.
+    contents:
+      - '@family tasks'
+  - title: Utilities
+    desc: Internal helpers used by the API client.
+    contents:
+      - '@family utilities'


### PR DESCRIPTION
## Summary
- Tag project, task, and utility functions with `@family` roxygen tags
- Introduce pkgdown configuration grouping reference pages by family
- Add build ignore file for pkgdown artifacts

## Testing
- `R -q -e 'devtools::document()'` *(fails: `bash: command not found: R`)*
- `R -q -e 'pkgdown::build_site()'` *(fails: `bash: command not found: R`)*


------
https://chatgpt.com/codex/tasks/task_e_68ae2994cc848332ba4ae721152c7d80